### PR TITLE
Fix: Fetch data when no concept or table type

### DIFF
--- a/src/dataops/models.py
+++ b/src/dataops/models.py
@@ -136,6 +136,18 @@ class CensusAPIEndpoint(BaseModel):
 
     @computed_field
     @property
+    def table_type(self) -> str:
+        dataset_parts = self.dataset.strip("/").split("/")
+        last = dataset_parts[-1]
+        middle = dataset_parts[1]
+
+        if last == middle:
+            return "not_table"
+        else:
+            return last
+
+    @computed_field
+    @property
     def concept(self) -> str:
         """Endpoint concept"""
         return self.fetch_variable_labels().select(pl.col("concept").unique()).item()

--- a/src/dataops/models.py
+++ b/src/dataops/models.py
@@ -150,7 +150,14 @@ class CensusAPIEndpoint(BaseModel):
     @property
     def concept(self) -> str:
         """Endpoint concept"""
-        return self.fetch_variable_labels().select(pl.col("concept").unique()).item()
+
+        if self.table_type != "not_table":
+            return (
+                self.fetch_variable_labels().select(pl.col("concept").unique()).item()
+            )
+
+        else:
+            return "no_concept"
 
     # --- Data Fetching Methods ---
 


### PR DESCRIPTION
This pull request introduces a new computed property, `table_type`, to the `src/dataops/models.py` file and updates the logic for the `concept` property to account for the new `table_type`. These changes enhance the model's ability to differentiate between datasets with and without table structures.

### Added functionality:

* **New computed property `table_type`:** Added a method to determine the type of table associated with a dataset based on its URL structure. If the last and middle parts of the dataset path match, it is classified as `"not_table"`, otherwise the last part is used as the table type. 

### Updated logic:

* **Modified `concept` property:** Updated the `concept` property to return `"no_concept"` when `table_type` is `"not_table"`. Otherwise, it fetches and selects the unique concept from variable labels as before. 