### PR TITLE
Fix new setting names

### DIFF
--- a/src/dataops/models.py
+++ b/src/dataops/models.py
@@ -31,13 +31,13 @@ class ApplicationSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
-    census_api_key: str = Field(..., env="CENSUS_API_KEY")
-    domain: str = Field(..., env="DOMAIN")
-    source_id: str = Field(..., env="SOURCE_ID")
-    target_id: str = Field(..., env="TARGET_ID")
-    socrata_user: str = Field(..., env="SOCRATA_USER")
-    socrata_pass: str = Field(..., env="SOCRATA_PASS")
-    socrata_token: str = Field(..., env="SOCRATA_TOKEN")
+    census_api_key: str = Field("", env="CENSUS_API_KEY")
+    domain: str = Field("", env="DOMAIN")
+    source_id: str = Field("", env="SOURCE_ID")
+    target_id: str = Field("", env="TARGET_ID")
+    socrata_user: str = Field("", env="SOCRATA_USER")
+    socrata_pass: str = Field("", env="SOCRATA_PASS")
+    socrata_token: str = Field("", env="SOCRATA_TOKEN")
 
 
 class CensusAPIEndpoint(BaseModel):

--- a/src/dataops/models.py
+++ b/src/dataops/models.py
@@ -33,12 +33,11 @@ class ApplicationSettings(BaseSettings):
 
     census_api_key: str = Field(..., env="CENSUS_API_KEY")
     domain: str = Field(..., env="DOMAIN")
-    table_source: str = Field(..., env="TABLE_SOURCE")
-    table_target: str = Field(..., env="TABLE_TARGET")
-    resource: str = Field(..., env="RESOURCE")
-    user: str = Field(..., env="USER")
-    password: str = Field(..., env="PASSWORD")
-    token: str = Field(..., env="TOKEN")
+    source_id: str = Field(..., env="SOURCE_ID")
+    target_id: str = Field(..., env="TARGET_ID")
+    socrata_user: str = Field(..., env="SOCRATA_USER")
+    socrata_pass: str = Field(..., env="SOCRATA_PASS")
+    socrata_token: str = Field(..., env="SOCRATA_TOKEN")
 
 
 class CensusAPIEndpoint(BaseModel):

--- a/src/dataops/portal.py
+++ b/src/dataops/portal.py
@@ -41,3 +41,25 @@ def pull_endpoints(df: pl.DataFrame) -> list[str] | pl.DataFrame:
 
     return df
 
+
+def replace_data(
+    data: pl.DataFrame,
+    target: str | None = None,
+    settings: ApplicationSettings | None = None,
+):
+    if settings is None:
+        settings = ApplicationSettings()
+    
+    if target is None:
+        target = settings.target_id
+
+
+    dict_data = data.to_dicts()
+
+    with Socrata(
+        settings.domain,
+        settings.socrata_token,
+        settings.socrata_user,
+        settings.socrata_pass,
+    ) as client:
+        client.replace(target, dict_data)

--- a/src/dataops/portal.py
+++ b/src/dataops/portal.py
@@ -4,7 +4,7 @@ from sodapy import Socrata
 
 
 def fetch_data(
-    resource: str | None = None,
+    source: str | None = None,
     settings: ApplicationSettings | None = None,
     lazy: bool = True,
 ) -> pl.LazyFrame | pl.DataFrame:
@@ -15,13 +15,16 @@ def fetch_data(
     if settings is None:
         settings = ApplicationSettings()
 
-    if resource is None:
-        resource = settings.resource
+    if source is None:
+        source = settings.source_id
 
     with Socrata(
-        settings.domain, settings.token, settings.user, settings.password
+        settings.domain,
+        settings.socrata_token,
+        settings.socrata_user,
+        settings.socrata_pass,
     ) as client:
-        data = client.get_all(resource)
+        data = client.get_all(source)
         data = pl.LazyFrame(data)
 
     if not lazy:
@@ -37,3 +40,4 @@ def pull_endpoints(df: pl.DataFrame) -> list[str] | pl.DataFrame:
         return df.select(pl.col("endpoint").struct.unnest()).to_series().to_list()
 
     return df
+

--- a/src/dataops/portal.py
+++ b/src/dataops/portal.py
@@ -49,10 +49,9 @@ def replace_data(
 ):
     if settings is None:
         settings = ApplicationSettings()
-    
+
     if target is None:
         target = settings.target_id
-
 
     dict_data = data.to_dicts()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,3 @@
-
 from src.dataops.models import CensusAPIEndpoint
 
 


### PR DESCRIPTION
This pull request introduces changes to the `src/dataops` module to improve clarity and functionality by renaming variables for better readability, updating the `ApplicationSettings` class, and adding a new function to replace data in Socrata. The most important changes are grouped into themes below.

### Updates to `ApplicationSettings`:

* Renamed fields in the `ApplicationSettings` class to use more descriptive names, such as `source_id` and `target_id` instead of `table_source` and `table_target`, and `socrata_user`, `socrata_pass`, and `socrata_token` instead of `user`, `password`, and `token`. Default values were also updated to empty strings for better initialization. (`src/dataops/models.py`, [src/dataops/models.pyL34-R40](diffhunk://#diff-8888e3d919a333d78814f55cfb771d23bc900572b50e5644800acc5d268d14b8L34-R40))

### Refactoring in `fetch_data`:

* Updated the `fetch_data` function to use the renamed `source_id` field instead of `resource`, and updated the Socrata client initialization to use the new `socrata_*` fields. (`src/dataops/portal.py`, [[1]](diffhunk://#diff-b30c78a97ae86316c70c4c2a839040346862d994094870c68c40860a37a79717L7-R7) [[2]](diffhunk://#diff-b30c78a97ae86316c70c4c2a839040346862d994094870c68c40860a37a79717L18-R27)

### New functionality:

* Added a new `replace_data` function to replace data in Socrata, leveraging the updated `ApplicationSettings` fields for configuration. (`src/dataops/portal.py`, [src/dataops/portal.pyR43-R64](diffhunk://#diff-b30c78a97ae86316c70c4c2a839040346862d994094870c68c40860a37a79717R43-R64))

### Minor cleanup:

* Removed an unused import in the `tests/test_models.py` file. (`tests/test_models.py`, [tests/test_models.pyL1](diffhunk://#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968L1))